### PR TITLE
Fix for #41 - Directories are shown as empty

### DIFF
--- a/lib/Storage/Flysystem.php
+++ b/lib/Storage/Flysystem.php
@@ -32,7 +32,7 @@ abstract class Flysystem extends \OC\Files\Storage\Flysystem
     protected function getContents()
     {
         if (count($this->cacheFileObjects) === 0) {
-            $this->cacheFileObjects = $this->flysystem->listContents($this->root);
+            $this->cacheFileObjects = $this->flysystem->listContents($this->root,true);
         }
 
         return $this->cacheFileObjects;


### PR DESCRIPTION
Unfortunatelly now app is scanning only root directory so this is why it can't find files in subdirectories. Probably there is possible to rewrite it to don't run scan on every directory change but this will need more investigation.