### PR TITLE
Fix relative path to gdrive.js

### DIFF
--- a/lib/Backend/Google.php
+++ b/lib/Backend/Google.php
@@ -43,6 +43,6 @@ class Google extends Backend
         // all parameters handled in OAuth2 mechanism
         ])
         ->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)
-        ->addCustomJs("../../../$appWebPath/js/gdrive");
+        ->addCustomJs("../../../..$appWebPath/js/gdrive");
     }
 }


### PR DESCRIPTION
The relative path was not correct on my installation to load the gdrive.js file.
The incorrect path was causing nextcloud to redirect to it's default page for the 
user which is text/html. This caused the error mentioned [here](https://github.com/NastuzziSamy/files_external_gdrive/issues/55#issuecomment-571754278).

And since the gdrive.js file was not loading, the Grant Access button was not working.

After applying this fix, Grant Access works.

https://github.com/NastuzziSamy/files_external_gdrive/issues/55