### PR TITLE
Fix oauth2 access: Invalid client_secret

### DIFF
--- a/js/gdrive.js
+++ b/js/gdrive.js
@@ -7,7 +7,8 @@ $(document).ready(function () {
 	}
 
 	OCA.Files_External.Settings.mountConfig.whenSelectAuthMechanism(function ($tr, authMechanism, scheme, onCompletion) {
-		if (authMechanism === 'oauth2::oauth2') {
+		if (authMechanism === 'oauth2::oauth2' &&
+			$tr.hasClass('files_external_gdrive')) {
 			var config = $tr.find('.configuration');
 			// hack to prevent conflict with oauth2 code from files_external
 			// wait for files_external to setup the config ui and then change the button
@@ -36,7 +37,7 @@ $(document).ready(function () {
 						&& typeof client_secret === "string"
 						&& client_secret !== ''
 					) {
-						$('.configuration').trigger('oauth_step2', [{
+						$('.configuration').trigger('gdrive_oauth_step2', [{
 							backend_id: $tr.attr('class'),
 							client_id: client_id,
 							client_secret: client_secret,
@@ -57,7 +58,7 @@ $(document).ready(function () {
 		var client_id = $(this).parent().find('[data-parameter="client_id"]').val().trim();
 		var client_secret = $(this).parent().find('[data-parameter="client_secret"]').val().trim();
 		if (client_id !== '' && client_secret !== '') {
-			$('.configuration').trigger('oauth_step1', [{
+			$('.configuration').trigger('gdrive_oauth_step1', [{
 				backend_id: tr.attr('class'),
 				client_id: client_id,
 				client_secret: client_secret,
@@ -67,20 +68,20 @@ $(document).ready(function () {
 		}
 	});
 
-	$('.configuration').on('oauth_step1', function (event, data) {
+	$('.configuration').on('gdrive_oauth_step1', function (event, data) {
 		if (data['backend_id'] !== backendId) {
 			return false;	// means the trigger is not for this storage adapter
 		}
 
-		OCA.Files_External.Settings.OAuth2.getAuthUrl(backendUrl, data);
+		OCA.Files_External.Settings.OAuth2.getGdriveAuthUrl(backendUrl, data);
 	});
 
-	$('.configuration').on('oauth_step2', function (event, data) {
+	$('.configuration').on('gdrive_oauth_step2', function (event, data) {
 		if (data['backend_id'] !== backendId || data['code'] === undefined) {
 			return false;		// means the trigger is not for this OAuth2 grant
 		}
 
-		OCA.Files_External.Settings.OAuth2.verifyCode(backendUrl, data)
+		OCA.Files_External.Settings.OAuth2.gdriveVerifyCode(backendUrl, data)
 			.fail(function (message) {
 				OC.dialogs.alert(message,
 					t(backendId, 'Error verifying OAuth2 Code for ' + backendId)
@@ -103,7 +104,7 @@ OCA.Files_External.Settings.OAuth2 = OCA.Files_External.Settings.OAuth2 || {};
  * @param  {String}   backendUrl The backend URL to which request will be sent
  * @param  {Object}   data       Keys -> (backend_id, client_id, client_secret, redirect, tr)
  */
-OCA.Files_External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
+OCA.Files_External.Settings.OAuth2.getGdriveAuthUrl = function (backendUrl, data) {
 	var $tr = data['tr'];
 	var configured = $tr.find('[data-parameter="configured"]');
 	var token = $tr.find('.configuration [data-parameter="token"]');
@@ -145,7 +146,7 @@ OCA.Files_External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
  * @param  {Object}   data       Keys -> (backend_id, client_id, client_secret, redirect, tr, code)
  * @return {Promise} jQuery Deferred Promise object
  */
-OCA.Files_External.Settings.OAuth2.verifyCode = function (backendUrl, data) {
+OCA.Files_External.Settings.OAuth2.gdriveVerifyCode = function (backendUrl, data) {
 	var $tr = data['tr'];
 	var configured = $tr.find('[data-parameter="configured"]');
 	var token = $tr.find('.configuration [data-parameter="token"]');

--- a/js/gdrive.js
+++ b/js/gdrive.js
@@ -24,6 +24,10 @@ $(document).ready(function () {
 				} else {
 					var client_id = $tr.find('.configuration [data-parameter="client_id"]').val().trim();
 					var client_secret = $tr.find('.configuration [data-parameter="client_secret"]').val().trim();
+					if (localStorage.getItem('files_external_gdrive_oauth2')) {
+						client_secret = atob(localStorage.getItem('files_external_gdrive_oauth2'));
+						localStorage.removeItem('files_external_gdrive_oauth2');
+					}
 
 					var params = {};
 					window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
@@ -125,6 +129,7 @@ OCA.Files_External.Settings.OAuth2.getGdriveAuthUrl = function (backendUrl, data
 							t('files_external', 'No URL provided by backend ' + data['backend_id'])
 						);
 					} else {
+						localStorage.setItem('files_external_gdrive_oauth2', btoa(data['client_secret']));
 						window.location = result.data.url;
 					}
 				});


### PR DESCRIPTION
This commits fixes "invalid_client_secret".

The problem was:

- With commit (nextcloud/server@0d112d7#diff-8b87ec33b8bfb6e79af3a46d287408d2) the client_secret was rewrite after reload (or backlink from oauth2) to "\_\_unmodified__"
- To fix this behavior this commit saves client_secret temporary in localstorage
- After reading from localstorage the client_secret would be deleted

Additionally:

- If an user selects google drive and dropbox or onedrive: The plugins overwritten each other's events.